### PR TITLE
ENH: Added Leiwandville, Flipdot POIs

### DIFF
--- a/src/projects/32c3/pois.json
+++ b/src/projects/32c3/pois.json
@@ -722,6 +722,14 @@
         "x": 630,
         "y": 341
     },
+    "flipdot": {
+        "groups": [
+            "assembly"
+        ],
+        "level": 1,
+        "x": 312,
+        "y": 523
+    },
     "food1": {
         "groups": [
             "catering"
@@ -948,6 +956,14 @@
         "level": 0,
         "x": 477,
         "y": 365
+    },
+    "leiwandville": {
+        "groups": [
+            "assembly"
+        ],
+        "level": 1,
+        "x": 813,
+        "y": 501
     },
     "lng": {
         "groups": [


### PR DESCRIPTION
Added the POIs for [Leiwandville](https://events.ccc.de/congress/2015/wiki/Assembly:Leiwandville) and [Flipdot](https://events.ccc.de/congress/2015/wiki/Assembly:Flipdot)
