### PR TITLE
fix mapinput in firefox

### DIFF
--- a/src/static/css/main.css
+++ b/src/static/css/main.css
@@ -16,6 +16,12 @@ h2, p {
 .p fieldset {
     min-width:0;
 }
+/* Firefox hack http://stackoverflow.com/a/17863685/3070886 */
+@-moz-document url-prefix() {
+    .p fieldset {
+        display: table-cell;
+    }
+}
 
 #main {
     margin:auto;


### PR DESCRIPTION
there is a rendering bug which only occurs in firefox. This should fix it.

Firefox:
<img width="970" alt="bildschirmfoto 2015-12-28 um 14 33 05" src="https://cloud.githubusercontent.com/assets/1328782/12019536/ccd6f998-ad71-11e5-8da2-91bac8ae1fe6.png">
Chrome:
<img width="940" alt="bildschirmfoto 2015-12-28 um 14 33 15" src="https://cloud.githubusercontent.com/assets/1328782/12019535/ccd13cce-ad71-11e5-8456-12542f25bbc2.png">

See: https://stackoverflow.com/questions/17408815/fieldset-resizes-wrong-appears-to-have-unremovable-min-width-min-content/17863685#17863685
